### PR TITLE
Remove unused variable hzExpComp

### DIFF
--- a/HSS.scad
+++ b/HSS.scad
@@ -3,7 +3,6 @@ grid = 1.27;
 
 diode_gauge_mm = 0.508;
 wire_gauge_mm = 0.559;
-hzExpComp = 1.15;
 
 pin2 = [-2*grid, 4*grid, 1.4];
 pin1 = [3*grid, 2*grid, 1.7];


### PR DESCRIPTION
Thank you for sharing awesome model.
It seems this variable is not used since this commit.

https://github.com/stingray127/handwirehotswap/commit/9f741a5382d0391134858281c8021c5f1ba1ac8c#diff-59269fed6dce06221820ead54486a228032bc058c15a2ba7b37c7dd973999db0